### PR TITLE
Develop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Adding portal_type list to IGndSettings to be able to choose for which portal_type the BEACON list is rendered. The list can be filled with a registry record [muellers]
+- Fixing error on modification date when result list is empty [muellers]
 
 
 1.1 (2019-12-09)

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.6",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*",
     install_requires=[
         'setuptools',
         # -*- Extra requirements: -*-

--- a/src/collective/gnd/controlpanels/gnd_settings.py
+++ b/src/collective/gnd/controlpanels/gnd_settings.py
@@ -41,6 +41,15 @@ class IGndSettings(Interface):
         readonly=False,
     )
 
+    portal_types = schema.Set(
+        title=_(u'Types to include in beacon list'),
+        description=_(u'Select the types for which the beacon list shall be rendered. If nothing selected, beacon list will contain all objects with gnd id'),
+        value_type=schema.Choice(
+            vocabulary='plone.app.vocabularies.UserFriendlyTypes',
+        ),
+        required=False,
+        readonly=False)
+
     render_all = schema.Bool(
         title=_(u'Render all?'),
         description=_(u'If enabled, all indexed GND-IDs will be listed in '

--- a/src/collective/gnd/controlpanels/gnd_settings.py
+++ b/src/collective/gnd/controlpanels/gnd_settings.py
@@ -4,7 +4,8 @@ from plone.app.registry.browser import controlpanel
 from plone.z3cform import layout
 from zope import schema
 from zope.interface import Interface
-
+from z3c.form.browser.orderedselect import OrderedSelectWidget
+from plone.autoform import directives
 
 class IGndSettings(Interface):
     """ Define settings data structure for registry"""
@@ -49,6 +50,8 @@ class IGndSettings(Interface):
         ),
         required=False,
         readonly=False)
+
+    directives.widget('portal_types', OrderedSelectWidget)
 
     render_all = schema.Bool(
         title=_(u'Render all?'),

--- a/src/collective/gnd/upgrades.py
+++ b/src/collective/gnd/upgrades.py
@@ -20,7 +20,7 @@ def to_1002(context):
     reload_gs_profile(context)
     # AS we added gnd_id to metadata columns, we need to reindex all objects
     # with a gnd_id.
-    brains = api.content.find(gnd_id={'query': 4, 'range': 'min'})
+    brains = api.content.find(gnd_id={'query': '', 'range': 'min'})
     log.info('Start reindexing index gnd_id on {0} objects.'
              .format(len(brains)))
     for brain in brains:

--- a/src/collective/gnd/views/beacon_gnd.py
+++ b/src/collective/gnd/views/beacon_gnd.py
@@ -43,8 +43,10 @@ class BeaconGnd(BrowserView):
                 brains = catalog(gnd_id={'query': '', 'range': 'min'}, portal_type=self.portal_types, sort_on='modified')
             else:
                 brains = catalog(gnd_id={'query': '', 'range': 'min'}, sort_on='modified')
-
-        self.ModificationDate = list(brains)[-1].ModificationDate
+        if brains:
+            self.ModificationDate = list(brains)[-1].ModificationDate
+        else:
+            self.ModificationDate = datetime.now()
         result = [brain.gnd_id for brain in brains]
         return result
 


### PR DESCRIPTION
### commit 'fixed wrong python_requires statement (comma is treated as logical AND)':
With setuptools==42.0.2 'python_requires' was not taken into account so the wrong statement was not noticed at buildout. But with the newer version there is always error for python version

### other commits:
Possibility to choose which portal_types shall be included to the beacon list